### PR TITLE
Update ChatMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.16]
+
+## Fixed
+
+- Type of `content` field for `ChatMessage` model
+
+## Added
+
+- New tests
+
 ## [0.7.15]
 
 ### Added

--- a/langgraph_agent_toolkit/schema/schema.py
+++ b/langgraph_agent_toolkit/schema/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, NotRequired
+from typing import Any, Dict, List, Literal, NotRequired
 
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
@@ -133,7 +133,7 @@ class ChatMessage(BaseModel):
         description="Role of the message.",
         examples=["human", "ai", "tool", "custom"],
     )
-    content: str | Dict[str, Any] = Field(
+    content: str | Dict[str, Any] | List[str | Dict[str, Any]] = Field(
         description="Content of the message.",
         examples=["Hello, world!"],
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-agent-toolkit"
-version = "0.7.15"
+version = "0.7.16"
 description = "Full toolkit for running an AI agent service built with LangGraph, FastAPI and Streamlit"
 readme = "README.md"
 authors = [{ name = "Roman Kryvokhyzha", email = "kriwohizha@gmail.com" }, { name = "Joshua Carroll", email = "carroll.joshk@gmail.com" }]
@@ -30,6 +30,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "rootutils >= 1.0.7",
     "duckduckgo-search >= 7.3.0",
+    "ddgs >= 9.5.0",
     "fastapi ~= 0.116.1",
     "grpcio >= 1.68.0",
     "httpx ~= 0.28.1",

--- a/tests/helper/test_helper_utils.py
+++ b/tests/helper/test_helper_utils.py
@@ -1,0 +1,200 @@
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    ToolMessage,
+)
+from langchain_core.messages import (
+    ChatMessage as LangchainChatMessage,
+)
+from pydantic import BaseModel
+
+from langgraph_agent_toolkit.helper.utils import langchain_to_chat_message
+from langgraph_agent_toolkit.schema import ChatMessage
+
+
+class TestLangchainToChatMessage:
+    """Tests for langchain_to_chat_message function."""
+
+    def test_human_message_with_string_content(self):
+        """Test converting HumanMessage with string content."""
+        message = HumanMessage(content="Hello, world!")
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "human"
+        assert result.content == "Hello, world!"
+
+    def test_human_message_with_list_content(self):
+        """Test converting HumanMessage with list content."""
+        content = ["Hello", {"type": "text", "text": " world!"}]
+        message = HumanMessage(content=content)
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "human"
+        assert result.content == content
+
+    def test_ai_message_with_string_content(self):
+        """Test converting AIMessage with string content."""
+        message = AIMessage(content="How can I help you?")
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == "How can I help you?"
+
+    def test_ai_message_with_tool_calls(self):
+        """Test converting AIMessage with tool calls."""
+        tool_calls = [{"name": "search", "args": {"query": "weather"}, "id": "call_1"}]
+        response_metadata = {"token_usage": {"total_tokens": 100}}
+
+        message = AIMessage(
+            content="Let me search for that.", tool_calls=tool_calls, response_metadata=response_metadata
+        )
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == "Let me search for that."
+        # LangChain automatically adds 'type': 'tool_call' to tool calls
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "search"
+        assert result.tool_calls[0]["args"] == {"query": "weather"}
+        assert result.tool_calls[0]["id"] == "call_1"
+        assert result.tool_calls[0]["type"] == "tool_call"
+        assert result.response_metadata == response_metadata
+
+    def test_ai_message_with_list_content(self):
+        """Test converting AIMessage with list content."""
+        content = [
+            {"type": "text", "text": "Here's the weather:"},
+            {"type": "image", "url": "http://example.com/weather.png"},
+        ]
+        message = AIMessage(content=content)
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == content
+
+    def test_tool_message(self):
+        """Test converting ToolMessage."""
+        message = ToolMessage(content="Weather is sunny, 25°C", tool_call_id="call_123")
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "tool"
+        assert result.content == "Weather is sunny, 25°C"
+        assert result.tool_call_id == "call_123"
+
+    def test_tool_message_with_list_content(self):
+        """Test converting ToolMessage with list content."""
+        content = [
+            {"type": "text", "text": "Weather data:"},
+            {"type": "data", "value": {"temperature": 25, "condition": "sunny"}},
+        ]
+        message = ToolMessage(content=content, tool_call_id="call_123")
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "tool"
+        assert result.content == content
+        assert result.tool_call_id == "call_123"
+
+    def test_langchain_chat_message_custom(self):
+        """Test converting LangchainChatMessage with custom role."""
+        custom_data = {"system": "initialization", "config": {"mode": "debug"}}
+        message = LangchainChatMessage(role="custom", content=[custom_data])
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "custom"
+        assert result.content == ""
+        assert result.custom_data == custom_data
+
+    def test_langchain_chat_message_unsupported_role(self):
+        """Test converting LangchainChatMessage with unsupported role."""
+        message = LangchainChatMessage(role="system", content="System message")
+
+        with pytest.raises(ValueError, match="Unsupported chat message role: system"):
+            langchain_to_chat_message(message)
+
+    def test_string_input(self):
+        """Test converting string input."""
+        result = langchain_to_chat_message("Hello from string")
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == "Hello from string"
+
+    def test_dict_input(self):
+        """Test converting dict input."""
+        input_dict = {"text": "Hello from dict", "metadata": {"source": "test"}}
+        result = langchain_to_chat_message(input_dict)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == input_dict
+
+    def test_dict_input_with_raw(self):
+        """Test converting dict input with raw field."""
+        raw_content = "Content from raw field"
+        input_dict = {"raw": Mock(content=raw_content), "other": "data"}
+        result = langchain_to_chat_message(input_dict)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == raw_content
+
+    def test_list_input(self):
+        """Test converting list input."""
+        input_list = [{"type": "text", "text": "Hello"}, {"type": "image", "url": "http://example.com/image.png"}]
+        result = langchain_to_chat_message(input_list)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == input_list
+
+    def test_pydantic_model_input(self):
+        """Test converting Pydantic BaseModel input."""
+
+        class TestModel(BaseModel):
+            message: str
+            priority: int
+
+        model = TestModel(message="Test message", priority=1)
+        result = langchain_to_chat_message(model)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == {"message": "Test message", "priority": 1}
+
+    def test_unsupported_message_type(self):
+        """Test converting unsupported message type."""
+        with pytest.raises(ValueError, match="Unsupported message type: int"):
+            langchain_to_chat_message(123)
+
+    def test_empty_list_input(self):
+        """Test converting empty list input."""
+        result = langchain_to_chat_message([])
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == []
+
+    def test_complex_nested_content(self):
+        """Test converting message with complex nested content."""
+        complex_content = [
+            "Text part",
+            {"type": "multimodal", "data": {"text": "Nested text", "metadata": {"source": "complex"}}},
+            {"type": "text", "text": "More text"},
+        ]
+        message = AIMessage(content=complex_content)
+        result = langchain_to_chat_message(message)
+
+        assert isinstance(result, ChatMessage)
+        assert result.type == "ai"
+        assert result.content == complex_content

--- a/uv.lock
+++ b/uv.lock
@@ -575,6 +575,20 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/ff/a6bb3bb2bf363530c07d4a8b809a051ce2f8fd28f5cafb2c7d3e7832847e/ddgs-9.5.5.tar.gz", hash = "sha256:9a09aa9ba24173d14321137c8c1bc54040ed0bf3bad956cb2f9feeda77968770", size = 33560, upload-time = "2025-09-01T13:25:14.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/aa/0ca4b396a3940a04120679e0c1d2fce534018ca90d92d8a83115f05f1263/ddgs-9.5.5-py3-none-any.whl", hash = "sha256:01fc8017a653ad16501bd8ac9fedcd29291f6500b1f8a7e92a916cdad7fc2fa2", size = 37922, upload-time = "2025-09-01T13:25:13.337Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1668,9 +1682,10 @@ wheels = [
 
 [[package]]
 name = "langgraph-agent-toolkit"
-version = "0.7.15"
+version = "0.7.16"
 source = { editable = "." }
 dependencies = [
+    { name = "ddgs" },
     { name = "duckduckgo-search" },
     { name = "fastapi" },
     { name = "fire" },
@@ -1793,6 +1808,7 @@ dev = [
 requires-dist = [
     { name = "azure-functions", marker = "extra == 'all-backends'", specifier = "~=1.23.0" },
     { name = "azure-functions", marker = "extra == 'azure-backend'", specifier = "~=1.23.0" },
+    { name = "ddgs", specifier = ">=9.5.0" },
     { name = "duckduckgo-search", specifier = ">=7.3.0" },
     { name = "fastapi", specifier = "~=0.116.1" },
     { name = "fire", specifier = "~=0.7.0" },


### PR DESCRIPTION
This pull request updates the handling of the `content` field in the `ChatMessage` model to support lists and improves compatibility with multimodal and structured content types. It also adds comprehensive tests for the conversion logic and updates dependencies and documentation.

### ChatMessage model and conversion logic improvements

* Updated the type of the `content` field in `ChatMessage` to accept `str`, `dict`, or a list of `str`/`dict`, enabling support for multimodal and structured messages. (`langgraph_agent_toolkit/schema/schema.py`)
* Modified the `langchain_to_chat_message` utility to handle list inputs and pass through content types without forced string conversion, improving flexibility and correctness. (`langgraph_agent_toolkit/helper/utils.py`) [[1]](diffhunk://#diff-1092c078a1ec190e979a33e9fb9aef08b009a043ea682ae38b4597506e3b1a95L39-R58) [[2]](diffhunk://#diff-1092c078a1ec190e979a33e9fb9aef08b009a043ea682ae38b4597506e3b1a95L67-R68) [[3]](diffhunk://#diff-1092c078a1ec190e979a33e9fb9aef08b009a043ea682ae38b4597506e3b1a95R82-R86)
* Updated type imports to support list typing. (`langgraph_agent_toolkit/schema/schema.py`)

### Testing

* Added a new test suite covering various scenarios for `langchain_to_chat_message`, including all supported content types, error cases, and edge cases. (`tests/helper/test_helper_utils.py`)

### Documentation and dependency updates

* Updated the changelog to document the fix for the `content` field type and the addition of new tests. (`CHANGELOG.md`)
* Bumped package version to `0.7.16` and added `ddgs` as a dependency. (`pyproject.toml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R33)