### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.11]
+
+### Fixed
+
+- Handling AIMessage that has tool calls without ToolMessage
+
 ## [0.8.10]
 
 ### Updated

--- a/langgraph_agent_toolkit/agents/components/creators/create_react_agent.py
+++ b/langgraph_agent_toolkit/agents/components/creators/create_react_agent.py
@@ -48,6 +48,7 @@ from langgraph.utils.runnable import RunnableCallable, RunnableLike
 from pydantic import BaseModel
 
 from langgraph_agent_toolkit.agents.components.utils import default_pre_model_hook
+from langgraph_agent_toolkit.helper.utils import sanitize_chat_history
 
 
 def _get_model(model: LanguageModelLike, config: RunnableConfig) -> BaseChatModel:
@@ -194,6 +195,10 @@ def create_react_agent(
 
         if messages is None:
             raise ValueError(error_msg)
+
+        # Sanitize chat history to remove incomplete tool calls before validation
+        # This handles cases where previous executions were interrupted
+        messages = sanitize_chat_history(messages)
 
         _validate_chat_history(messages)
         # we're passing messages under `messages` key, as this is expected by the prompt

--- a/langgraph_agent_toolkit/helper/utils.py
+++ b/langgraph_agent_toolkit/helper/utils.py
@@ -104,6 +104,56 @@ def remove_tool_calls(content: str | list[str | dict]) -> str | list[str | dict]
     ]
 
 
+def sanitize_chat_history(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Sanitize chat history by removing AIMessages with tool_calls that don't have corresponding ToolMessages.
+
+    This is useful when:
+    - A previous execution was interrupted before tool responses were added
+    - Chat history was corrupted
+    - Connection was lost during tool execution
+
+    Args:
+        messages: List of messages to sanitize
+
+    Returns:
+        Sanitized list of messages where all AIMessages with tool_calls have corresponding ToolMessages
+
+    """
+    if not messages:
+        return messages
+
+    # Collect all tool_call_ids that have corresponding ToolMessages
+    tool_message_ids: set[str] = set()
+    for msg in messages:
+        if isinstance(msg, ToolMessage) and msg.tool_call_id:
+            tool_message_ids.add(msg.tool_call_id)
+
+    # Process messages and fix incomplete tool calls
+    sanitized_messages: list[BaseMessage] = []
+    for msg in messages:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            # Check if all tool_calls have corresponding ToolMessages
+            incomplete_calls = [call for call in msg.tool_calls if call.get("id") not in tool_message_ids]
+            if incomplete_calls:
+                # Create a new AIMessage without the incomplete tool_calls
+                complete_calls = [call for call in msg.tool_calls if call.get("id") in tool_message_ids]
+                # If no complete calls remain, remove tool_calls entirely
+                new_msg = AIMessage(
+                    content=msg.content or "[Tool call was interrupted]",
+                    id=msg.id,
+                    name=msg.name,
+                    tool_calls=complete_calls if complete_calls else [],
+                    response_metadata=msg.response_metadata,
+                )
+                sanitized_messages.append(new_msg)
+            else:
+                sanitized_messages.append(msg)
+        else:
+            sanitized_messages.append(msg)
+
+    return sanitized_messages
+
+
 def create_ai_message(parts: dict) -> AIMessage:
     sig = inspect.signature(AIMessage)
     valid_keys = set(sig.parameters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-agent-toolkit"
-version = "0.8.10"
+version = "0.8.11"
 description = "Full toolkit for running an AI agent service built with LangGraph, FastAPI and Streamlit"
 readme = "README.md"
 authors = [{ name = "Roman Kryvokhyzha", email = "kriwohizha@gmail.com" }, { name = "Joshua Carroll", email = "carroll.joshk@gmail.com" }]

--- a/tests/helper/test_helper_utils.py
+++ b/tests/helper/test_helper_utils.py
@@ -9,9 +9,10 @@ from langchain_core.messages import (
 from langchain_core.messages import (
     ChatMessage as LangchainChatMessage,
 )
+from langgraph.prebuilt.chat_agent_executor import _validate_chat_history
 from pydantic import BaseModel
 
-from langgraph_agent_toolkit.helper.utils import langchain_to_chat_message
+from langgraph_agent_toolkit.helper.utils import langchain_to_chat_message, sanitize_chat_history
 from langgraph_agent_toolkit.schema import ChatMessage
 
 
@@ -200,3 +201,245 @@ class TestLangchainToChatMessage:
         assert isinstance(result, ChatMessage)
         assert result.type == "ai"
         assert result.content == complex_content
+
+
+class TestSanitizeChatHistory:
+    """Tests for sanitize_chat_history function."""
+
+    def test_empty_messages(self):
+        """Test sanitizing empty message list."""
+        result = sanitize_chat_history([])
+        assert result == []
+
+    def test_messages_without_tool_calls(self):
+        """Test sanitizing messages without any tool calls."""
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there!"),
+            HumanMessage(content="How are you?"),
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 3
+        assert result[0].content == "Hello"
+        assert result[1].content == "Hi there!"
+        assert result[2].content == "How are you?"
+
+    def test_complete_tool_call_chain(self):
+        """Test sanitizing messages with complete tool call chain (AIMessage + ToolMessage)."""
+        tool_call_id = "call_123"
+        messages = [
+            HumanMessage(content="Search for weather"),
+            AIMessage(
+                content="Let me search",
+                tool_calls=[{"name": "search", "args": {"query": "weather"}, "id": tool_call_id, "type": "tool_call"}],
+            ),
+            ToolMessage(content="Weather is sunny", tool_call_id=tool_call_id),
+            AIMessage(content="The weather is sunny!"),
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 4
+        # Complete tool call should remain
+        assert len(result[1].tool_calls) == 1
+        assert result[1].tool_calls[0]["id"] == tool_call_id
+
+    def test_incomplete_tool_call(self):
+        """Test sanitizing messages with incomplete tool call (AIMessage without ToolMessage)."""
+        messages = [
+            HumanMessage(content="Search for weather"),
+            AIMessage(
+                content="Let me search",
+                tool_calls=[{"name": "search", "args": {"query": "weather"}, "id": "call_123", "type": "tool_call"}],
+            ),
+            # No ToolMessage for call_123
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 2
+        # Tool calls should be removed from the AIMessage
+        assert result[1].tool_calls == []
+        assert result[1].content == "Let me search"
+
+    def test_incomplete_tool_call_with_empty_content(self):
+        """Test sanitizing incomplete tool call when AIMessage has empty content."""
+        messages = [
+            HumanMessage(content="Search"),
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "search", "args": {}, "id": "call_456", "type": "tool_call"}],
+            ),
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 2
+        # Tool calls should be removed and content should indicate interruption
+        assert result[1].tool_calls == []
+        assert result[1].content == "[Tool call was interrupted]"
+
+    def test_partial_tool_calls_completed(self):
+        """Test sanitizing messages where some tool calls are complete and others are not."""
+        messages = [
+            HumanMessage(content="Search and calculate"),
+            AIMessage(
+                content="Let me help",
+                tool_calls=[
+                    {"name": "search", "args": {"query": "data"}, "id": "call_complete", "type": "tool_call"},
+                    {"name": "calculator", "args": {"expr": "2+2"}, "id": "call_incomplete", "type": "tool_call"},
+                ],
+            ),
+            ToolMessage(content="Search result", tool_call_id="call_complete"),
+            # No ToolMessage for call_incomplete
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 3
+        # Only the complete tool call should remain
+        assert len(result[1].tool_calls) == 1
+        assert result[1].tool_calls[0]["id"] == "call_complete"
+
+    def test_multiple_incomplete_tool_calls(self):
+        """Test sanitizing messages with multiple consecutive incomplete tool calls."""
+        messages = [
+            HumanMessage(content="Query 1"),
+            AIMessage(
+                content="Processing 1",
+                tool_calls=[{"name": "tool1", "args": {}, "id": "call_1", "type": "tool_call"}],
+            ),
+            HumanMessage(content="Query 2"),
+            AIMessage(
+                content="Processing 2",
+                tool_calls=[{"name": "tool2", "args": {}, "id": "call_2", "type": "tool_call"}],
+            ),
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 4
+        # Both AIMessages should have their tool_calls removed
+        assert result[1].tool_calls == []
+        assert result[3].tool_calls == []
+
+    def test_preserves_message_metadata(self):
+        """Test that sanitization preserves other message metadata."""
+        messages = [
+            AIMessage(
+                id="msg_id_123",
+                content="Original content",
+                name="agent_name",
+                tool_calls=[{"name": "search", "args": {}, "id": "call_1", "type": "tool_call"}],
+                response_metadata={"model": "gpt-4"},
+            ),
+        ]
+        result = sanitize_chat_history(messages)
+
+        assert len(result) == 1
+        assert result[0].id == "msg_id_123"
+        assert result[0].name == "agent_name"
+        assert result[0].response_metadata == {"model": "gpt-4"}
+        assert result[0].tool_calls == []
+
+
+class TestValidateChatHistoryErrorReproduction:
+    """Tests demonstrating the original error and how sanitize_chat_history fixes it."""
+
+    def test_validate_chat_history_raises_on_incomplete_tool_calls(self):
+        """Reproduce the original error: _validate_chat_history raises ValueError for incomplete tool calls.
+
+        This demonstrates the error:
+        ValueError: Found AIMessages with tool_calls that do not have a corresponding ToolMessage.
+        """
+        # This is the problematic message history that caused the original error
+        messages = [
+            HumanMessage(content="FK1252CE water filter"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "QdrantSemanticSearch",
+                        "args": {"question": "FK1252CE water filter"},
+                        "id": "call_HqrkPBmCwWJwQ5QedeAvwSy4",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            # Missing ToolMessage for call_HqrkPBmCwWJwQ5QedeAvwSy4
+        ]
+
+        # This should raise ValueError - reproducing the original error
+        with pytest.raises(
+            ValueError, match="Found AIMessages with tool_calls that do not have a corresponding ToolMessage"
+        ):
+            _validate_chat_history(messages)
+
+    def test_sanitize_fixes_incomplete_tool_calls_before_validation(self):
+        """Demonstrate that sanitize_chat_history fixes the issue before validation."""
+        # Same problematic message history
+        messages = [
+            HumanMessage(content="FK1252CE water filter"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "QdrantSemanticSearch",
+                        "args": {"question": "FK1252CE water filter"},
+                        "id": "call_HqrkPBmCwWJwQ5QedeAvwSy4",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+        ]
+
+        # Sanitize first
+        sanitized = sanitize_chat_history(messages)
+
+        # Now validation should pass without raising
+        _validate_chat_history(sanitized)  # No exception raised
+
+        # Verify the tool calls were removed
+        assert sanitized[1].tool_calls == []
+        assert sanitized[1].content == "[Tool call was interrupted]"
+
+    def test_validate_passes_with_complete_tool_call_chain(self):
+        """Verify that _validate_chat_history passes when tool calls have corresponding ToolMessages."""
+        tool_call_id = "call_complete_123"
+        messages = [
+            HumanMessage(content="Search for weather"),
+            AIMessage(
+                content="Let me search",
+                tool_calls=[{"name": "search", "args": {"query": "weather"}, "id": tool_call_id, "type": "tool_call"}],
+            ),
+            ToolMessage(content="Weather is sunny", tool_call_id=tool_call_id),
+            AIMessage(content="The weather is sunny!"),
+        ]
+
+        # Should not raise - complete tool call chain
+        _validate_chat_history(messages)
+
+    def test_multiple_tool_calls_one_missing_response(self):
+        """Reproduce error when one of multiple tool calls is missing its response."""
+        messages = [
+            HumanMessage(content="Search and calculate"),
+            AIMessage(
+                content="I'll help with both",
+                tool_calls=[
+                    {"name": "search", "args": {"query": "data"}, "id": "call_search", "type": "tool_call"},
+                    {"name": "calculator", "args": {"expr": "2+2"}, "id": "call_calc", "type": "tool_call"},
+                ],
+            ),
+            ToolMessage(content="Search result", tool_call_id="call_search"),
+            # Missing ToolMessage for call_calc
+        ]
+
+        # This should raise because call_calc has no corresponding ToolMessage
+        with pytest.raises(
+            ValueError, match="Found AIMessages with tool_calls that do not have a corresponding ToolMessage"
+        ):
+            _validate_chat_history(messages)
+
+        # Sanitize should fix it
+        sanitized = sanitize_chat_history(messages)
+        _validate_chat_history(sanitized)  # No exception
+
+        # Only complete tool call remains
+        assert len(sanitized[1].tool_calls) == 1
+        assert sanitized[1].tool_calls[0]["id"] == "call_search"


### PR DESCRIPTION
This pull request introduces a fix to handle interrupted or incomplete tool call chains in chat histories, preventing errors when validating or processing agent conversations. The core improvement is the addition of a `sanitize_chat_history` utility, which ensures that all `AIMessage` tool calls have corresponding `ToolMessage` responses, and removes or amends any that do not. This makes the toolkit more robust against connection issues or partial executions. Comprehensive tests are included to verify the new behavior.

Key changes include:

**Bug Fixes & Core Functionality:**

* Added the `sanitize_chat_history` function in `helper/utils.py` to remove or amend `AIMessage` entries with tool calls that lack corresponding `ToolMessage` responses, addressing issues caused by interrupted executions or corrupted chat logs.
* Updated the agent creation logic in `create_react_agent.py` to sanitize chat history before validation, ensuring that only valid message sequences are processed. [[1]](diffhunk://#diff-2925081a00925783ebfc24f01d339803a29a215d2b33e8b240d0760fce92f92aR51) [[2]](diffhunk://#diff-2925081a00925783ebfc24f01d339803a29a215d2b33e8b240d0760fce92f92aR199-R202)

**Testing:**

* Added extensive unit tests in `test_helper_utils.py` to cover various scenarios for `sanitize_chat_history`, including empty histories, complete and incomplete tool call chains, metadata preservation, and error reproduction/fix workflows.

**Documentation & Versioning:**

* Updated the `CHANGELOG.md` to document the fix for handling `AIMessage` tool calls without corresponding `ToolMessage` entries.
* Bumped the package version to `0.8.11` in `pyproject.toml` to reflect the new release.